### PR TITLE
chore: specify directory that project lives in

### DIFF
--- a/packages/eslint-plugin-lube/package.json
+++ b/packages/eslint-plugin-lube/package.json
@@ -17,7 +17,8 @@
 	"name": "eslint-plugin-lube",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Artxe2/lube-series"
+		"url": "https://github.com/Artxe2/lube-series",
+		"directory": "packages/eslint-plugin-lube"
 	},
 	"scripts": {
 		"test": "mocha"


### PR DESCRIPTION
I just did it for this one plugin, but you might want to do it for all of them